### PR TITLE
Fixes for server rendering and undefined values

### DIFF
--- a/src/react-inline-auto-prefixer.js
+++ b/src/react-inline-auto-prefixer.js
@@ -73,6 +73,10 @@ let neededCssValues = {
 };
 
 let clientPrefix = (function vendorPrefix(){
+  if(typeof navigator === 'undefined') {
+    return []
+  }
+  
   let sUsrAg = navigator.userAgent;
 
   if(includes(sUsrAg, 'Chrome')) { return webkit; }

--- a/src/react-inline-auto-prefixer.js
+++ b/src/react-inline-auto-prefixer.js
@@ -219,8 +219,8 @@ function checkAndAddPrefix(styleObj, key, val, allVendors){
 
 
 function autoPrefixer(obj, allVendors){
-  Object.keys(obj).forEach( (key) => {
-    let val = obj[key];
+  obj && Object.keys(obj).forEach( (key) => {
+    let val = obj[key] || '';
     if (typeof val === 'object'){
       autoPrefixer(val, allVendors);
     } else {


### PR DESCRIPTION
Fixes for a few issues I ran into when trying to user auto-prefixer:
- navigator.userAgent does not exist on the server and so a Reference Error is thrown.  
- when passing a style object through from a higher level component (see example below), in some cases the style is not set, or values are `undefined`.  Calling `Object.keys` on an `undefined` value causes an Error to be thrown.

``` javascript
render() {
  var { style, ...props } = this.props
  return <Component style={autoprefix(style)} {...props} />
}
```
