### PR TITLE
Return no client prefixes when user agent does not match

### DIFF
--- a/src/react-inline-auto-prefixer.js
+++ b/src/react-inline-auto-prefixer.js
@@ -84,6 +84,8 @@ let clientPrefix = (function vendorPrefix(){
   else if (includes(sUsrAg, 'Opera')) { return webkitO; }
   else if (includes(sUsrAg, 'Firefox')) { return moz; }
   else if (includes(sUsrAg, 'MSIE')) { return ms; }
+  
+  return [];
 })();
 
 function checkAndAddPrefix(styleObj, key, val, allVendors){


### PR DESCRIPTION
When the user agent does not include one of the expected strings, a value should still be returned from the `vendorPrefix()` function so that later, when calling `includes`, an error is not thrown.  This error manifests on IE11 because of its ["hard-to-sniff"](http://blogs.msdn.com/b/ieinternals/archive/2013/09/21/internet-explorer-11-user-agent-string-ua-string-sniffing-compatibility-with-gecko-webkit.aspx) user agent.
